### PR TITLE
Fixed that the processor output interval was slower than the theoretical value

### DIFF
--- a/src/js/game/systems/item_processor.js
+++ b/src/js/game/systems/item_processor.js
@@ -20,10 +20,8 @@ export class ItemProcessorSystem extends GameSystemWithFilter {
             const ejectorComp = entity.components.ItemEjector;
 
             // First of all, process the current recipe
-            if (processorComp.secondsUntilEject > 0) {
-                processorComp.secondsUntilEject =
-                    processorComp.secondsUntilEject - this.root.dynamicTickrate.deltaSeconds;
-            }
+            processorComp.secondsUntilEject =
+                processorComp.secondsUntilEject - this.root.dynamicTickrate.deltaSeconds;
 
             if (G_IS_DEV && globalConfig.debug.instantProcessors) {
                 processorComp.secondsUntilEject = 0;
@@ -81,6 +79,11 @@ export class ItemProcessorSystem extends GameSystemWithFilter {
                         this.startNewCharge(entity);
                     }
                 }
+            }
+
+            // Remove time carryover if processing is not continuous
+            if (processorComp.secondsUntilEject < 0) {
+                processorComp.secondsUntilEject = 0;
             }
         }
     }

--- a/src/js/game/systems/item_processor.js
+++ b/src/js/game/systems/item_processor.js
@@ -106,9 +106,7 @@ export class ItemProcessorSystem extends GameSystemWithFilter {
         }
 
         const baseSpeed = this.root.hubGoals.getProcessorBaseSpeed(processorComp.type);
-        if (processorComp.secondsUntilEject <= 0) {
-            processorComp.secondsUntilEject += 1 / baseSpeed;
-        }
+        processorComp.secondsUntilEject += 1 / baseSpeed;
 
         /** @type {Array<{item: BaseItem, requiredSlot?: number, preferredSlot?: number}>} */
         const outItems = [];

--- a/src/js/game/systems/item_processor.js
+++ b/src/js/game/systems/item_processor.js
@@ -19,11 +19,16 @@ export class ItemProcessorSystem extends GameSystemWithFilter {
             const processorComp = entity.components.ItemProcessor;
             const ejectorComp = entity.components.ItemEjector;
 
-            // First of all, process the current recipe
-            processorComp.secondsUntilEject =
-                processorComp.secondsUntilEject - this.root.dynamicTickrate.deltaSeconds;
+            if (processorComp.secondsUntilEject > 0) {
+                // First of all, process the current recipe
+                processorComp.secondsUntilEject =
+                    processorComp.secondsUntilEject - this.root.dynamicTickrate.deltaSeconds;
 
-            if (G_IS_DEV && globalConfig.debug.instantProcessors) {
+                if (G_IS_DEV && globalConfig.debug.instantProcessors) {
+                    processorComp.secondsUntilEject = 0;
+                }
+            } else {
+                // Remove time carryover if processing is not continuous
                 processorComp.secondsUntilEject = 0;
             }
 
@@ -79,11 +84,6 @@ export class ItemProcessorSystem extends GameSystemWithFilter {
                         this.startNewCharge(entity);
                     }
                 }
-            }
-
-            // Remove time carryover if processing is not continuous
-            if (processorComp.secondsUntilEject < 0) {
-                processorComp.secondsUntilEject = 0;
             }
         }
     }

--- a/src/js/game/systems/item_processor.js
+++ b/src/js/game/systems/item_processor.js
@@ -20,10 +20,10 @@ export class ItemProcessorSystem extends GameSystemWithFilter {
             const ejectorComp = entity.components.ItemEjector;
 
             // First of all, process the current recipe
-            processorComp.secondsUntilEject = Math.max(
-                0,
-                processorComp.secondsUntilEject - this.root.dynamicTickrate.deltaSeconds
-            );
+            if (processorComp.secondsUntilEject > 0) {
+                processorComp.secondsUntilEject =
+                    processorComp.secondsUntilEject - this.root.dynamicTickrate.deltaSeconds;
+            }
 
             if (G_IS_DEV && globalConfig.debug.instantProcessors) {
                 processorComp.secondsUntilEject = 0;
@@ -31,7 +31,7 @@ export class ItemProcessorSystem extends GameSystemWithFilter {
 
             // Check if we have any finished items we can eject
             if (
-                processorComp.secondsUntilEject === 0 && // it was processed in time
+                processorComp.secondsUntilEject <= 0 && // it was processed in time
                 processorComp.itemsToEject.length > 0 // we have some items left to eject
             ) {
                 for (let itemIndex = 0; itemIndex < processorComp.itemsToEject.length; ++itemIndex) {
@@ -103,7 +103,9 @@ export class ItemProcessorSystem extends GameSystemWithFilter {
         }
 
         const baseSpeed = this.root.hubGoals.getProcessorBaseSpeed(processorComp.type);
-        processorComp.secondsUntilEject = 1 / baseSpeed;
+        if (processorComp.secondsUntilEject <= 0) {
+            processorComp.secondsUntilEject += 1 / baseSpeed;
+        }
 
         /** @type {Array<{item: BaseItem, requiredSlot?: number, preferredSlot?: number}>} */
         const outItems = [];


### PR DESCRIPTION
The remainder of the calculation of the output interval of the processor is added to the next output.
Normally, the next process of the processor should be running faster by that time.
This is equivalent to an extractor referencing in-game time.

![PR_processor_speed](https://user-images.githubusercontent.com/809200/86861753-c22c4d00-c102-11ea-9987-7e370e8a71da.png)
