### PR TITLE
Await asynchronous mod initialization

### DIFF
--- a/src/js/mods/modloader.js
+++ b/src/js/mods/modloader.js
@@ -263,7 +263,7 @@ export class ModLoader {
                     settings,
                     saveSettings: () => storage.writeFileAsync(modDataFile, JSON.stringify(mod.settings)),
                 });
-                mod.init();
+                await mod.init();
                 this.mods.push(mod);
             } catch (ex) {
                 console.error(ex);


### PR DESCRIPTION
This change allows mods to delay the game loading process until they're ready. An example of such mod is [Custom CSS/LESS](https://github.com/dengr1065/shapez-mods/tree/master/src/custom_css), which needs to run early and currently relies on the built-in settings system, caching the transpiled CSS.

Use cases:
 - Read custom configuration/settings files before the game loads
 - Wait for third-party/WebAssembly code to load
 - Do other kinds of I/O, such as network calls