### PR TITLE
Add "reveal" FS job and a wrapper

### DIFF
--- a/electron/index.js
+++ b/electron/index.js
@@ -336,6 +336,11 @@ ipcMain.handle("fs-job", async (event, job) => {
             return;
         }
 
+        case "reveal": {
+            shell.showItemInFolder(fname);
+            return;
+        }
+
         default:
             throw new Error("Unknown fs job: " + job.type);
     }

--- a/electron_gog/index.js
+++ b/electron_gog/index.js
@@ -335,6 +335,11 @@ ipcMain.handle("fs-job", async (event, job) => {
             return;
         }
 
+        case "reveal": {
+            shell.showItemInFolder(fname);
+            return;
+        }
+
         default:
             throw new Error("Unknown fs job: " + job.type);
     }

--- a/src/js/platform/electron/storage.js
+++ b/src/js/platform/electron/storage.js
@@ -38,4 +38,11 @@ export class StorageImplElectron extends StorageInterface {
             filename,
         });
     }
+
+    revealFileAsync(filename) {
+        return ipcRenderer.invoke("fs-job", {
+            type: "reveal",
+            filename,
+        });
+    }
 }


### PR DESCRIPTION
Another small feature to complement #1485. Allows mods to "reveal" files in the `saves/` directory by opening the file manager and highlighting the specified file. Relevant Electron docs: https://www.electronjs.org/docs/latest/api/shell#shellshowiteminfolderfullpath

Test case:
```js
const METADATA = {
  name: "Reveal FS Job Test",
  description: "",
  version: "1.0.0",
  author: "dengr1065",
  website: "",
  id: "reveal-fs-job-test",
  doesNotAffectSavegame: true
};

class Mod extends shapez.Mod {
  file = `${METADATA.id}_custom_file`

  async init() {
    const storage = new StorageImplElectron(this.app);
    await storage.initialize();
    
    // File does not exist (just open the directory or do nothing)
    await storage.revealFileAsync(this.file);
    
    // Wait 10 seconds before the file is created
    await new Promise((resolve) => setTimeout(() => resolve(), 10e3));
    
    // Create a new file
    await storage.writeFileAsync(this.file, "");
    
    // Open the directory (and select the file) in file manager
    await storage.revealFileAsync(this.file);
    
    // Delay to ensure that the file is visible for some time
    await new Promise((resolve) => setTimeout(() => resolve(), 10e3));
    
    // Delete the file once the test is done
    await storage.deleteFileAsync(this.file);
  }
}
```