### PR TITLE
Migrated array of entities in entity_manager.js to map using uid as key

### DIFF
--- a/src/js/game/core.js
+++ b/src/js/game/core.js
@@ -440,7 +440,7 @@ export class GameCore {
         this.overlayAlpha = lerp(this.overlayAlpha, desiredOverlayAlpha, 0.25);
 
         // On low performance, skip the fade
-        if (this.root.entityMgr.entities.length > 5000 || this.root.dynamicTickrate.averageFps < 50) {
+        if (this.root.entityMgr.entities.size > 5000 || this.root.dynamicTickrate.averageFps < 50) {
             this.overlayAlpha = desiredOverlayAlpha;
         }
 

--- a/src/js/game/hud/parts/puzzle_editor_settings.js
+++ b/src/js/game/hud/parts/puzzle_editor_settings.js
@@ -93,7 +93,7 @@ export class HUDPuzzleEditorSettings extends BaseHUDPart {
 
     trim() {
         // Now, find the center
-        const buildings = this.root.entityMgr.entities.slice();
+        const buildings = Array.from(this.root.entityMgr.entities.values());
 
         if (buildings.length === 0) {
             // nothing to do

--- a/src/js/game/hud/parts/wires_overlay.js
+++ b/src/js/game/hud/parts/wires_overlay.js
@@ -64,7 +64,7 @@ export class HUDWiresOverlay extends BaseHUDPart {
         const desiredAlpha = this.root.currentLayer === "wires" ? 1.0 : 0.0;
 
         // On low performance, skip the fade
-        if (this.root.entityMgr.entities.length > 5000 || this.root.dynamicTickrate.averageFps < 50) {
+        if (this.root.entityMgr.entities.size > 5000 || this.root.dynamicTickrate.averageFps < 50) {
             this.currentAlpha = desiredAlpha;
         } else {
             this.currentAlpha = lerp(this.currentAlpha, desiredAlpha, 0.12);

--- a/src/js/game/logic.js
+++ b/src/js/game/logic.js
@@ -473,7 +473,7 @@ export class GameLogic {
      * Clears all belts and items
      */
     clearAllBeltsAndItems() {
-        for (const entity of this.root.entityMgr.entities) {
+        for (const entity of this.root.entityMgr.entities.values()) {
             for (const component of Object.values(entity.components)) {
                 /** @type {Component} */ (component).clear();
             }

--- a/src/js/savegame/savegame_serializer.js
+++ b/src/js/savegame/savegame_serializer.js
@@ -37,7 +37,7 @@ export class SavegameSerializer {
             gameMode: root.gameMode.serialize(),
             entityMgr: root.entityMgr.serialize(),
             hubGoals: root.hubGoals.serialize(),
-            entities: this.internal.serializeEntityArray(root.entityMgr.entities),
+            entities: this.internal.serializeEntityMap(root.entityMgr.entities),
             beltPaths: root.systemMgr.systems.belt.serializePaths(),
             pinnedShapes: root.hud.parts.pinnedShapes ? root.hud.parts.pinnedShapes.serialize() : null,
             waypoints: root.hud.parts.waypoints ? root.hud.parts.waypoints.serialize() : null,
@@ -86,7 +86,7 @@ export class SavegameSerializer {
             }
             seenUids.add(uid);
 
-            // Verify components
+            // Verify components/
             if (!entity.components) {
                 return ExplainedResult.bad("Entity is missing key 'components': " + JSON.stringify(entity));
             }

--- a/src/js/savegame/serializer_internal.js
+++ b/src/js/savegame/serializer_internal.js
@@ -11,12 +11,11 @@ const logger = createLogger("serializer_internal");
 export class SerializerInternal {
     /**
      * Serializes an array of entities
-     * @param {Array<Entity>} array
+     * @param {Map<number, Entity>} map
      */
-    serializeEntityArray(array) {
+    serializeEntityMap(map) {
         const serialized = [];
-        for (let i = 0; i < array.length; ++i) {
-            const entity = array[i];
+        for (const entity of map.values()) {
             if (!entity.queuedForDestroy && !entity.destroyed) {
                 serialized.push(entity.serialize());
             }


### PR DESCRIPTION
I started running into very slow load/save times in my main world where I built my MAM (~200,000 buildings).

After some investigation using a profile in Chrome, I found that the `registerEntity` function is the culprit of the long load times, more specifically the use of an array to keep track of the entities. The current implementation of `registerEntity` uses `indexOf` to check whether an entity is already registered, which has a quadratic complexity (`O(n^2)`) when registering a substantial amount of entities.

The entity manager already makes use of a UID to distinguish between entity, implements some map-like functionality, such as `findById`, and there is a function that constructs a map which maps UID to entities. All considering, I opted to migrate the list of entities to a map which uses the UID as a key, and replaced some of the aforementioned functionality with their `Map` counterparts.

Theoretically this should already improve loading times, since the complexity of `O(n^2)` is brought down to `O(n log(n))`. But practical results are more fun 😄. I loaded my 200,000 building world up in Chrome (I played on Steam before), and the loading time went down to 10 seconds, whereas right now it takes substantially longer, I tried timing it but after 7 mins in a loading screen I had enough.