### PR TITLE
Remove emphasis in Cutter in `base-en.yaml`

### DIFF
--- a/translations/base-en.yaml
+++ b/translations/base-en.yaml
@@ -835,10 +835,10 @@ buildings:
     cutter:
         default:
             name: &cutter Cutter
-            description: Cuts shapes from top to bottom and outputs both halves. <strong>If you use only one part, be sure to destroy the other part or it will clog and stall!</strong>
+            description: Cuts shapes from top to bottom and outputs both halves. If you use only one part, be sure to destroy the other part or it will clog and stall!
         quad:
             name: Cutter (Quad)
-            description: Cuts shapes into four parts. <strong>If you use only one part, be sure to destroy the other parts or it will clog and stall!</strong>
+            description: Cuts shapes into four parts. If you use only one part, be sure to destroy the other parts or it will clog and stall!
 
     rotater:
         default:


### PR DESCRIPTION
Removed `strong` tags as they aren't necessary.
Here, it emphasizes the warning as if it was a very important warning which I believe is not true.
If you go against the warning, you'll lose some temporary efficiency, but that's all. It's just part of learning the game, 
hence not needing to be in a strong font

You might also want to remove the exclamation mark or even the whole warning.