### PR TITLE
Change runnable-texturepacker url for decoupling s3 geo infomation.

### DIFF
--- a/gulp/image-resources.js
+++ b/gulp/image-resources.js
@@ -18,7 +18,7 @@ const nonImageResourcesGlobs = ["../res/**/*.woff2", "../res/*.ico", "../res/**/
 const imageResourcesGlobs = ["../res/**/*.png", "../res/**/*.svg", "../res/**/*.jpg", "../res/**/*.gif"];
 
 // Link to download LibGDX runnable-texturepacker.jar
-const runnableTPSource = "https://libgdx-nightlies.s3.eu-central-1.amazonaws.com/libgdx-runnables/runnable-texturepacker.jar";
+const runnableTPSource = "https://libgdx-nightlies.s3.amazonaws.com/libgdx-runnables/runnable-texturepacker.jar";
 
 function gulptasksImageResources($, gulp, buildFolder) {
     // Lossless options


### PR DESCRIPTION
Change geo specific domain to generic aws-s3 domain, and let s3 auto redirect to closest location.